### PR TITLE
Enable Codecov integration

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -45,3 +45,8 @@ jobs:
 
       - uses: julia-actions/julia-runtest@latest
         continue-on-error: ${{ matrix.version == 'nightly' }}
+      - name: "Process code coverage"
+        uses: julia-actions/julia-processcoverage@v1
+      - name: "Upload coverage data to Codecov"
+        continue-on-error: true
+        uses: codecov/codecov-action@v3

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # RandomExtensions
 
 [![Tests Status](https://github.com/JuliaRandom/RandomExtensions.jl/workflows/CI/badge.svg)](https://github.com/JuliaRandom/RandomExtensions.jl/actions?query=workflow%3ACI)
+[![codecov](https://codecov.io/gh/JuliaRandom/RandomExtensions.jl/graph/badge.svg?token=3crLCcitZR)](https://codecov.io/gh/JuliaRandom/RandomExtensions.jl)
 [![](https://img.shields.io/badge/docs-stable-blue.svg)](https://JuliaRandom.github.io/RandomExtensions.jl/stable)
 [![](https://img.shields.io/badge/docs-dev-blue.svg)](https://JuliaRandom.github.io/RandomExtensions.jl/dev)
 


### PR DESCRIPTION
Also update some actions to their latest version.

Note that this may require additional admin action, e.g.
adding / enabling the Codecov integration from the GitHub
marketplace for this repository.