### PR TITLE
Update CI config

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -1,7 +1,16 @@
 name: CI
+
 on:
   - push
   - pull_request
+
+concurrency:
+  # group by workflow and ref; the last slightly strange component ensures that for pull
+  # requests, we limit to 1 concurrent job, but for the master branch we don't
+  group: ${{ github.workflow }}-${{ github.ref }}-${{ github.ref != 'refs/heads/master' || github.run_number }}
+  # Cancel intermediate builds, but only if it is a pull request build.
+  cancel-in-progress: ${{ startsWith(github.ref, 'refs/pull/') }}
+
 jobs:
   test:
     name: Julia ${{ matrix.version }} - ${{ matrix.os }} - ${{ matrix.arch }}
@@ -28,22 +37,8 @@ jobs:
           version: ${{ matrix.version }}
           arch: ${{ matrix.arch }}
 
-      - uses: actions/cache@v3
-        env:
-          cache-name: cache-artifacts
-        with:
-          path: ~/.julia/artifacts
-          key: ${{ runner.os }}-test-${{ env.cache-name }}-${{ hashFiles('**/Project.toml') }}
-          restore-keys: |
-            ${{ runner.os }}-test-${{ env.cache-name }}-
-            ${{ runner.os }}-test-
-            ${{ runner.os }}-
-
-      - run: |
-          git config --global user.name Tester
-          git config --global user.email te@st.er
-
-      - uses: julia-actions/julia-runtest@latest
+      - uses: julia-actions/cache@v1
+      - uses: julia-actions/julia-runtest@v1
         continue-on-error: ${{ matrix.version == 'nightly' }}
       - name: "Process code coverage"
         uses: julia-actions/julia-processcoverage@v1


### PR DESCRIPTION
- cancel concurrent PR builds (we only care about the last one anyway)
- use julia-actions/cache action
- use v1 of julia-actions/julia-runtest, not latest, so we benefit from
  the usual semver protections against breaking changes
